### PR TITLE
Add AdminClient for adminv1gprc

### DIFF
--- a/pkg/gpcore/client/client.go
+++ b/pkg/gpcore/client/client.go
@@ -1,13 +1,15 @@
 package client
 
 import (
+	"crypto/tls"
+	"fmt"
+
+	"buf.build/gen/go/gportal/gpcore/grpc/go/gpcore/api/admin/v1/adminv1grpc"
 	"buf.build/gen/go/gportal/gpcore/grpc/go/gpcore/api/auth/v1/authv1grpc"
 	"buf.build/gen/go/gportal/gpcore/grpc/go/gpcore/api/cloud/v1/cloudv1grpc"
 	"buf.build/gen/go/gportal/gpcore/grpc/go/gpcore/api/metadata/v1/metadatav1grpc"
 	"buf.build/gen/go/gportal/gpcore/grpc/go/gpcore/api/network/v1/networkv1grpc"
 	"buf.build/gen/go/gportal/gpcore/grpc/go/gpcore/api/payment/v1/paymentv1grpc"
-	"crypto/tls"
-	"fmt"
 	"google.golang.org/grpc/credentials"
 
 	"google.golang.org/grpc"
@@ -20,6 +22,11 @@ type Client struct {
 }
 
 type EndpointOverrideOption string
+
+// AdminClient Returns the AdminServiceClient
+func (c *Client) AdminClient() adminv1grpc.AdminServiceClient {
+	return adminv1grpc.NewAdminServiceClient(c.grpcClient)
+}
 
 // CloudClient Returns the CloudServiceClient
 func (c *Client) CloudClient() cloudv1grpc.CloudServiceClient {


### PR DESCRIPTION
When trying to use gpcore to access GPortal GameServer functions I found the required AdminClient to be missing.

This PR adds the AdminClient to the current client implementation.
The missing bump for the latest protobuf is also included.